### PR TITLE
Create an action to build the wasm

### DIFF
--- a/.github/workflows/build_libzim_wasm.yml
+++ b/.github/workflows/build_libzim_wasm.yml
@@ -1,0 +1,25 @@
+name: Docker Image CI
+
+on:
+  # push:
+  #   branches: [ "master" ]
+  # pull_request:
+  #   branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build -t "docker-emscripten-libzim:v3" ./docker
+    - name: Compile the libzim WASM
+      run: docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) -it docker-emscripten-libzim:v3 make
+    - name: Publish the WASM to draft release
+      run: |
+        echo 'If the run was successful, we will build a publish action here, to publish:'
+        ls -l a.out.*


### PR DESCRIPTION
This is an initial go to run the docker build and compile on GitHub actions. For now it will just list the files if it completes successfully. If it is successful, I'll then use an action to upload the artefacts.