### PR TITLE
Update release/nightly uploads for new destination

### DIFF
--- a/.github/workflows/build_libzim_wasm.yml
+++ b/.github/workflows/build_libzim_wasm.yml
@@ -49,7 +49,7 @@ env:
   DISPATCH_TYPE: ${{ github.event.inputs.buildtype }}
   LIBZIM_VERSION: ${{ github.event.inputs.libzim_version }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SSH_KEY: ${{ secrets.SSH_KEY }}
+  UPLOAD_SSH_KEY: ${{ secrets.JAVASCRIPTLIBZIM_FILE_UPLOAD_KEY }}
   BUILD_TYPE: ${{ github.event.inputs.buildtype }}
 
 jobs:
@@ -124,8 +124,8 @@ jobs:
     - name: Zip the artefacts and upload to nightly
       if: github.event.schedule || github.event.inputs.buildtype == 'nightly'
       run: |
-        echo "$SSH_KEY" > ./scripts/ssh_key
-        chmod 600 ./scripts/ssh_key
+        echo "$UPLOAD_SSH_KEY" > ./scripts/upload_ssh_key
+        chmod 600 ./scripts/upload_ssh_key
         CURRENT_DATE=$(date +'%Y-%m-%d')
         target="/data/openzim/nightly/$CURRENT_DATE"
         zip libzim-javascript_wasm_$CURRENT_DATE.zip libzim-wasm.*
@@ -133,5 +133,5 @@ jobs:
         for FILE in "libzim-javascript_wasm_$CURRENT_DATE.zip" "libzim-javascript_asm_$CURRENT_DATE.zip"
         do
           echo "Copying $FILE to $target"
-          scp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$FILE" ci@master.download.kiwix.org:$target
+          scp -P 30322 -o StrictHostKeyChecking=no -i ./scripts/upload_ssh_key "$FILE" javascript-libzim@master.download.kiwix.org:$target
         done

--- a/.github/workflows/upload_release_assets_to_kiwix.yml
+++ b/.github/workflows/upload_release_assets_to_kiwix.yml
@@ -21,7 +21,7 @@ env:
   VERSION: ${{ github.event.release.tag_name }}
   DISPATCH_VERSION: ${{ github.event.inputs.version }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SSH_KEY: ${{ secrets.SSH_KEY }}
+  UPLOAD_SSH_KEY: ${{ secrets.JAVASCRIPTLIBZIM_FILE_UPLOAD_KEY }}
 
 jobs:
   upload:
@@ -40,9 +40,9 @@ jobs:
           exit 1
         }
         echo "`nUsing tag: $version for version upload`n"
-        $SSH_KEY = $Env:SSH_KEY
-        if (! $SSH_KEY) {
+        $UPLOAD_SSH_KEY = $Env:UPLOAD_SSH_KEY
+        if (! $UPLOAD_SSH_KEY) {
           Write-Warning "The SSH secret is empty!"
         }
-        echo "$SSH_KEY" > .\scripts\ssh_key
+        echo "$UPLOAD_SSH_KEY" > .\scripts\upload_ssh_key
         ./scripts/Upload-KiwixRelease.ps1 -yes

--- a/scripts/Upload-KiwixRelease.ps1
+++ b/scripts/Upload-KiwixRelease.ps1
@@ -128,11 +128,11 @@ function Main {
         $releaseFiles | % {
             $filename = $_
             if ($dryrun) {
-                "[DRYRUN] C:\Program Files\Git\usr\bin\scp.exe -P 30022 -o StrictHostKeyChecking=no -i $keyfile $filename ci@${server}:$target"
+                "[DRYRUN] C:\Program Files\Git\usr\bin\scp.exe -P 30322 -o StrictHostKeyChecking=no -i $keyfile $filename javascript-libzim@${server}:$target"
                 Write-Warning "No file was uploaded because this is a dry run.`n"
             } else {
                 # Uploading file
-                & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "ci@${server}:$target")
+                & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "javascript-libzim@${server}:$target")
                 Write-Host "`nUploaded $filename to $server$target"
             }
         }


### PR DESCRIPTION
As part of a server/infra change, the upload of nightly and release builds is done to a new destination.

The receiving service now uses per-project (well per-repo) users with independent SSH Keys. Each users now only has access to the folders in which it is expected to upload files.

- Host remains the same: `master.download.kiwix.org`
- Username changes from `ci` to `javascript-libzim`
- Port changes from `30022` to `30322`
- Paths remains the same

I also changed some variable names to make things more explicit.


⚠️ DO NOT MERGE AT THE MOMENT