### PR TITLE
Migrate to org-level KIWIX_FILE_UPLOAD_SSH_KEY secret

### DIFF
--- a/.github/workflows/build_libzim_wasm.yml
+++ b/.github/workflows/build_libzim_wasm.yml
@@ -49,7 +49,7 @@ env:
   DISPATCH_TYPE: ${{ github.event.inputs.buildtype }}
   LIBZIM_VERSION: ${{ github.event.inputs.libzim_version }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  UPLOAD_SSH_KEY: ${{ secrets.JAVASCRIPTLIBZIM_FILE_UPLOAD_KEY }}
+  UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
   BUILD_TYPE: ${{ github.event.inputs.buildtype }}
 
 jobs:

--- a/.github/workflows/upload_release_assets_to_kiwix.yml
+++ b/.github/workflows/upload_release_assets_to_kiwix.yml
@@ -21,7 +21,7 @@ env:
   VERSION: ${{ github.event.release.tag_name }}
   DISPATCH_VERSION: ${{ github.event.inputs.version }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  UPLOAD_SSH_KEY: ${{ secrets.JAVASCRIPTLIBZIM_FILE_UPLOAD_KEY }}
+  UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
 
 jobs:
   upload:

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 /libzim_wasm-*.tar.gz
 /large_file_*
 ssh_key
+upload_ssh_key
 github_token
 /node_modules/

--- a/scripts/Upload-KiwixRelease.ps1
+++ b/scripts/Upload-KiwixRelease.ps1
@@ -1,5 +1,5 @@
 # A script to find release assets and upload them to the Kiwix release server.
-# If run loaclly, you must ensure that the KIWIX_FILE_UPLOAD_SSH_KEY secret to access the release server is available in
+# If run locally, you must ensure that the KIWIX_FILE_UPLOAD_SSH_KEY secret to access the release server is available in
 # your File System, as scripts/upload_ssh_key (this is the file the workflow writes the secret to).
 # You should also provide the tag version as input to this script, or set the $version variable to an existing release tag.
 

--- a/scripts/Upload-KiwixRelease.ps1
+++ b/scripts/Upload-KiwixRelease.ps1
@@ -1,5 +1,6 @@
 # A script to find release assets and upload them to the Kiwix release server.
-# If run loaclly, you must ensure that the SSH_KEY secret to access the release server is available in your File System.
+# If run loaclly, you must ensure that the KIWIX_FILE_UPLOAD_SSH_KEY secret to access the release server is available in
+# your File System, as scripts/upload_ssh_key (this is the file the workflow writes the secret to).
 # You should also provide the tag version as input to this script, or set the $version variable to an existing release tag.
 
 param (
@@ -122,7 +123,7 @@ function Main {
             }
         }
         # Load the secret
-        $keyfile = "$PSScriptRoot\ssh_key"
+        $keyfile = "$PSScriptRoot\upload_ssh_key"
         $keyfile = $keyfile -ireplace '[\\/]', '/'
         ""
         $releaseFiles | % {


### PR DESCRIPTION
Both upload workflows now read the org-level secret (scoped to this repo) rather than the repo-level copy, so the key can be rotated in one place. Fixes #101.

Also repairs the key file path in Upload-KiwixRelease.ps1. In 1d6689d the workflow was changed to write the secret to scripts/upload_ssh_key, but the script still passed scripts/ssh_key to scp, so the release upload could not authenticate. That workflow has had no runs since, so this went unnoticed.

The new filename is added to .gitignore: the existing 'ssh_key' pattern matches that basename only, which would have left a private key untracked but visible in the working tree after a local run.