### PR TITLE
Use working upload key until org secret fixed

### DIFF
--- a/.github/workflows/build_libzim_wasm.yml
+++ b/.github/workflows/build_libzim_wasm.yml
@@ -49,7 +49,10 @@ env:
   DISPATCH_TYPE: ${{ github.event.inputs.buildtype }}
   LIBZIM_VERSION: ${{ github.event.inputs.libzim_version }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+  # Reverted to the repo-level secret: the org-level KIWIX_FILE_UPLOAD_SSH_KEY as currently stored
+  # fails to parse ("error in libcrypto: unsupported"), so no upload can authenticate with it.
+  # Switch back to secrets.KIWIX_FILE_UPLOAD_SSH_KEY once the org secret has been re-stored (#101).
+  UPLOAD_SSH_KEY: ${{ secrets.JAVASCRIPTLIBZIM_FILE_UPLOAD_KEY }}
   BUILD_TYPE: ${{ github.event.inputs.buildtype }}
 
 jobs:

--- a/.github/workflows/upload_release_assets_to_kiwix.yml
+++ b/.github/workflows/upload_release_assets_to_kiwix.yml
@@ -21,7 +21,10 @@ env:
   VERSION: ${{ github.event.release.tag_name }}
   DISPATCH_VERSION: ${{ github.event.inputs.version }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+  # Reverted to the repo-level secret: the org-level KIWIX_FILE_UPLOAD_SSH_KEY as currently stored
+  # fails to parse ("error in libcrypto: unsupported"), so no upload can authenticate with it.
+  # Switch back to secrets.KIWIX_FILE_UPLOAD_SSH_KEY once the org secret has been re-stored (#101).
+  UPLOAD_SSH_KEY: ${{ secrets.JAVASCRIPTLIBZIM_FILE_UPLOAD_KEY }}
 
 jobs:
   upload:

--- a/scripts/Upload-KiwixRelease.ps1
+++ b/scripts/Upload-KiwixRelease.ps1
@@ -139,6 +139,7 @@ function Main {
         $keyfile = "$PSScriptRoot\upload_ssh_key"
         $keyfile = $keyfile -ireplace '[\\/]', '/'
         ""
+        $uploadFailed = $false
         $releaseFiles | % {
             $filename = $_
             if ($dryrun) {
@@ -147,8 +148,17 @@ function Main {
             } else {
                 # Uploading file
                 & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "javascript-libzim@${server}:$target")
-                Write-Host "`nUploaded $filename to $server$target"
+                # Don't claim success on scp's behalf: it reports transfer and auth failures by exit code
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "`nUploaded $filename to $server$target"
+                } else {
+                    Write-Host "`n** scp exited with code $LASTEXITCODE :" $filename "was NOT uploaded! **`n" -ForegroundColor Red
+                    $uploadFailed = $true
+                }
             }
+        }
+        if ($uploadFailed) {
+            exit 1
         }
     } else {
         # This shouldn't happen!


### PR DESCRIPTION
The org secret for upload to OpenZim releases errors out, whereas the repo-level secret works fine. So I have to revert #112 and re-open #101 temporarily.